### PR TITLE
Enable support for the notify_plugin package which depneds on libesmtp-dev

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+collectd (5.1.0-2) unstable; urgency=low
+
+  * enable support notify_email plugin via dependency on libesmtp-dev.
+
+-- Aaron Kulick <akulick@krux.com>  Mon, 16 Jun 2014 22:48:53 +0000
+
 collectd (5.1.0-1) unstable; urgency=low
 
   * Initial debianization.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: collectd
 Section: unknown
 Priority: extra
 Maintainer: Paul Lathrop <plathrop@krux.com>
-Build-Depends: cdbs, debhelper (>= 7), autotools-dev, libvarnishapi-dev, libsnmp-dev, liboping-dev, python-dev, libcurl3, libsnmp-dev, apache2-prefork-dev, libesmtp-dev
+Build-Depends: cdbs, debhelper (>= 7), autotools-dev, libvarnishapi-dev, libsnmp-dev, liboping-dev, python-dev, libcurl3, libsnmp-dev, apache2-prefork-dev, libesmtp-dev, libesmtp5
 Standards-Version: 3.8.3
 Homepage: http://collectd.org/
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: collectd
 Section: unknown
 Priority: extra
 Maintainer: Paul Lathrop <plathrop@krux.com>
-Build-Depends: cdbs, debhelper (>= 7), autotools-dev, libvarnishapi-dev, libsnmp-dev, liboping-dev, python-dev, libcurl3, libsnmp-dev, apache2-prefork-dev
+Build-Depends: cdbs, debhelper (>= 7), autotools-dev, libvarnishapi-dev, libsnmp-dev, liboping-dev, python-dev, libcurl3, libsnmp-dev, apache2-prefork-dev, libesmtp-dev
 Standards-Version: 3.8.3
 Homepage: http://collectd.org/
 


### PR DESCRIPTION
The collectd notify_email plugin has an implicit dependency on libesmtp which must be present and available in order to be built during compilation.
